### PR TITLE
fixed encoding in setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     description = f.read()
 
 setuptools.setup(


### PR DESCRIPTION
The setup.py failed due to invalid encoding in the reading the readme.md file. added utf-8 encoding and solved.